### PR TITLE
Proxy Module

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -72,7 +72,9 @@ class Client
      */
     public function getUri()
     {
-        return new GuzzleHttp\Psr7\Uri('https://'.$this->domain.'/api/v3');
+        return new GuzzleHttp\Psr7\Uri(
+            sprintf('https://%s/api/v3/', $this->domain)
+        );
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -66,6 +66,16 @@ class Client
     }
 
     /**
+     * Get the URI.
+     *
+     * @return GuzzleHttp\Psr7\Uri
+     */
+    public function getUri()
+    {
+        return new GuzzleHttp\Psr7\Uri('https://'.$this->domain.'/api/v3');
+    }
+
+    /**
      * Get Omneo bearer token.
      *
      * @return string
@@ -125,7 +135,7 @@ class Client
 
         $this->client = new GuzzleHttp\Client(array_merge([
             'handler'  => $stack,
-            'base_uri' => 'https://'.$this->domain.'/api/v3/'
+            'base_uri' => (string) $this->getUri()
         ], $options));
 
         return $this;

--- a/src/Client.php
+++ b/src/Client.php
@@ -73,7 +73,7 @@ class Client
     public function getUrl()
     {
         return new GuzzleHttp\Psr7\Uri(
-            sprintf('http://%s/api/v3/', $this->domain)
+            sprintf('https://%s/api/v3/', $this->domain)
         );
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -66,14 +66,14 @@ class Client
     }
 
     /**
-     * Get the URI.
+     * Get the URL.
      *
      * @return GuzzleHttp\Psr7\Uri
      */
-    public function getUri()
+    public function getUrl()
     {
         return new GuzzleHttp\Psr7\Uri(
-            sprintf('https://%s/api/v3/', $this->domain)
+            sprintf('http://%s/api/v3/', $this->domain)
         );
     }
 
@@ -137,7 +137,7 @@ class Client
 
         $this->client = new GuzzleHttp\Client(array_merge([
             'handler'  => $stack,
-            'base_uri' => (string) $this->getUri()
+            'base_uri' => (string) $this->getUrl()
         ], $options));
 
         return $this;

--- a/src/Modules/BuildsModules.php
+++ b/src/Modules/BuildsModules.php
@@ -70,11 +70,23 @@ trait BuildsModules
     }
 
     /**
+     * Return attributes module.
+     *
      * @param Contracts\HasUri $owner
      * @return Attributes
      */
     public function attributes(Contracts\HasUri $owner)
     {
         return new Attributes($this, $owner);
+    }
+
+    /**
+     * Return proxy module.
+     *
+     * @return Proxy
+     */
+    public function proxy()
+    {
+        return new Proxy($this);
     }
 }

--- a/src/Modules/Proxy.php
+++ b/src/Modules/Proxy.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Omneo\Modules;
+
+use GuzzleHttp;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class Proxy extends Module
+{
+    /**
+     * Proxy a request.
+     *
+     * @param RequestInterface $request
+     * @param null $normalisedPath
+     * @return ResponseInterface
+     */
+    public function send(RequestInterface $request, $normalisedPath = null)
+    {
+        // Create URI from configured endpoint.
+        $endpoint = $this->client->getUri();
+
+        // Initialise our new URI with configured host.
+        $uri = $request->getUri()
+            ->withScheme($endpoint->getScheme())
+            ->withHost($endpoint->getHost());
+
+        if ($normalisedPath) {
+            $uri = $uri->withPath($normalisedPath);
+        }
+
+        if ($endpoint->getPath()) {
+            $uri = $uri->withPath($endpoint->getPath().$uri->getPath());
+        }
+
+        try {
+            return $this->parseProxyResponse($this->client->send($request->withUri($uri)));
+        } catch (GuzzleHttp\Exception\RequestException $e) {
+            if ($e->hasResponse()) {
+                return $this->parseProxyResponse($e->getResponse());
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Parse upstream proxy response before passing downstream.
+     *
+     * Here, we remove irrelevant upstream headers. If we pass these down, they may no longer match actual response
+     * characteristics (e.g. transfer-encoding chunked) and will cause browser problems.
+     *
+     * @param  ResponseInterface $response
+     * @return ResponseInterface
+     */
+    protected function parseProxyResponse(ResponseInterface $response)
+    {
+        return $response
+            ->withoutHeader('transfer-encoding')
+            ->withoutHeader('connection')
+            ->withoutHeader('server')
+            ->withoutHeader('date');
+    }
+}

--- a/src/Modules/Proxy.php
+++ b/src/Modules/Proxy.php
@@ -18,7 +18,7 @@ class Proxy extends Module
     public function send(RequestInterface $request, $normalisedPath = null)
     {
         // Create URI from configured endpoint.
-        $endpoint = $this->client->getUri();
+        $endpoint = $this->client->getUrl();
 
         // Initialise our new URI with configured host.
         $uri = $request->getUri()

--- a/src/Modules/Proxy.php
+++ b/src/Modules/Proxy.php
@@ -23,6 +23,7 @@ class Proxy extends Module
         // Initialise our new URI with configured host.
         $uri = $request->getUri()
             ->withScheme($endpoint->getScheme())
+            ->withPort($endpoint->getPort())
             ->withHost($endpoint->getHost());
 
         if ($normalisedPath) {
@@ -34,7 +35,9 @@ class Proxy extends Module
         }
 
         try {
-            return $this->parseProxyResponse($this->client->send($request->withUri($uri)));
+            return $this->parseProxyResponse(
+                $this->client->send($request->withUri($uri))
+            );
         } catch (GuzzleHttp\Exception\RequestException $e) {
             if ($e->hasResponse()) {
                 return $this->parseProxyResponse($e->getResponse());


### PR DESCRIPTION
This PR implements a proxy module for the Omneo PHP SDK.

Example:

```
return $client->proxy()->send(
    (new DiactorosFactory)->createRequest($request), // Convert the Laravel request to a PSR-7 compatible request.
    $endpoint
);
```
