### PR TITLE
Adds identity search

### DIFF
--- a/src/Modules/BuildsModules.php
+++ b/src/Modules/BuildsModules.php
@@ -23,7 +23,7 @@ trait BuildsModules
      * @param  Contracts\HasUri  $owner
      * @return Identities
      */
-    public function identities(Contracts\HasUri $owner)
+    public function identities(Contracts\HasUri $owner = null)
     {
         return new Identities($this, $owner);
     }

--- a/src/Modules/Identities.php
+++ b/src/Modules/Identities.php
@@ -3,6 +3,7 @@
 namespace Omneo\Modules;
 
 use Omneo\Client;
+use Omneo\Constraint;
 use Omneo\Identity;
 use Omneo\Contracts;
 use Illuminate\Support\Collection;
@@ -23,11 +24,27 @@ class Identities extends Module
      * @param  Client  $client
      * @param  Contracts\HasUri  $owner
      */
-    public function __construct(Client $client, Contracts\HasUri $owner)
+    public function __construct(Client $client, Contracts\HasUri $owner = null)
     {
         parent::__construct($client);
 
         $this->owner = $owner;
+    }
+
+    /**
+     * Fetch a listing of root identities.
+     *
+     * @param Constraint $constraint
+     * @return \Omneo\PaginatedCollection|Identity[]
+     */
+    public function search(Constraint $constraint = null)
+    {
+        return $this->buildPaginatedCollection(
+            $this->client->get('identities', $this->applyConstraint($constraint)),
+            Identity::class,
+            [$this, __FUNCTION__],
+            $constraint
+        );
     }
 
     /**

--- a/tests/Modules/IdentitiesTest.php
+++ b/tests/Modules/IdentitiesTest.php
@@ -24,6 +24,32 @@ class IdentitiesTest extends Omneo\TestCase
     /**
      * @test
      */
+    public function search_returns_paginated_collection()
+    {
+        $module = new Identities(
+            $client = m::mock(Omneo\Client::class)
+        );
+
+        $client
+            ->shouldReceive('get')
+            ->with('identities', [])
+            ->once()
+            ->andReturn(
+                new GuzzleHttp\Psr7\Response(200, [], $this->stub('identities/paginated-collection.json'))
+            );
+
+        $collection = $module->search();
+
+        $this->assertInstanceOf(Omneo\PaginatedCollection::class, $collection);
+        $this->assertEquals(1, $collection->currentPage());
+        $this->assertEquals(2, $collection->count());
+        $this->assertEquals(1, $collection->lastPage());
+        $this->assertEquals(2, $collection->total());
+    }
+
+    /**
+     * @test
+     */
     public function browse_returns_collection_of_identities()
     {
         $module = new Identities(

--- a/tests/stubs/identities/paginated-collection.json
+++ b/tests/stubs/identities/paginated-collection.json
@@ -1,0 +1,39 @@
+{
+  "data": [
+    {
+      "id": 2,
+      "handle": "zendesk",
+      "identifier": "123",
+      "is_primary": false,
+      "is_active": true,
+      "profile_id": "b1d6f3ec-38cd-4747-b7f3-6649c9c05c5d",
+      "created_at": "2018-04-24 06:31:51",
+      "updated_at": "2018-04-24 06:31:51"
+    },
+    {
+      "id": 3,
+      "handle": "mailchimp",
+      "identifier": "987",
+      "is_primary": false,
+      "is_active": true,
+      "profile_id": "b1d6f3ec-38cd-4747-b7f3-6649c9c05c5d",
+      "created_at": "2018-04-24 06:31:51",
+      "updated_at": "2018-04-24 06:31:51"
+    }
+  ],
+  "links": {
+    "first": "http://ap21-stage.omneoapp.com/api/v3/identities?page=1",
+    "last": "http://ap21-stage.omneoapp.com/api/v3/identities?page=1",
+    "prev": null,
+    "next": null
+  },
+  "meta": {
+    "current_page": 1,
+    "from": 1,
+    "last_page": 1,
+    "path": "http://ap21-stage.omneoapp.com/api/v3/identities",
+    "per_page": 2,
+    "to": 2,
+    "total": 2
+  }
+}


### PR DESCRIPTION
This PR introduces enhancements to the Identities module:

* Adds supports for top level identity search, e.g. api/v3/identities
* Adds support for limit and offset constraints

Usage:

```
return $this->client->identities()->search(
   (new Omneo\Constraint)->where('handle', 'shopify')->where('identifier', '1234')->limit(1)
)->first();
```