### PR TITLE
Add string casting and keys to identities

### DIFF
--- a/src/Identity.php
+++ b/src/Identity.php
@@ -4,5 +4,13 @@ namespace Omneo;
 
 class Identity extends Entity
 {
-    //
+    /**
+     * Cast identity to a string.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return (string) $this->identifier;
+    }
 }

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -39,7 +39,7 @@ class Profile extends Entity implements Contracts\HasUri
         return (new Collection((array) $attribute))
             ->map(function (array $identity) {
                 return new Identity($identity);
-            });
+            })->keyBy('handle');
     }
 
     /**

--- a/tests/IdentityTest.php
+++ b/tests/IdentityTest.php
@@ -20,4 +20,16 @@ class IdentityTest extends Omneo\TestCase
         $this->assertEquals('zendesk', $identity->handle);
         $this->assertEquals('123', $identity->identifier);
     }
+
+    /**
+     * @test
+     */
+    public function can_cast_to_string()
+    {
+        $identity = new Omneo\Identity(
+            $this->jsonStub('identities/entity.json')['data']
+        );
+
+        $this->assertEquals('123', (string) $identity);
+    }
 }

--- a/tests/ProfileTest.php
+++ b/tests/ProfileTest.php
@@ -56,6 +56,8 @@ class ProfileTest extends Omneo\TestCase
 
         $this->assertEquals('zendesk', $profile->identities->first()->handle);
         $this->assertEquals('XYZ', $profile->identities->first()->identifier);
+
+        $this->assertEquals(['zendesk'], $profile->identities->keys()->toArray());
     }
 
     /**


### PR DESCRIPTION
This PR adds string casting and keyed collections to identities. This means that you can do something like the following for easier identity value access.

```php
(string) $profile->identities->get('zendesk');
```

Previously, you would of had to do something like...

```php
$profile->identities->where('handle', 'zendesk')->first()->identifier;
```