### PR TITLE
Product & Product Variant Support

### DIFF
--- a/src/Modules/BuildsModules.php
+++ b/src/Modules/BuildsModules.php
@@ -40,6 +40,27 @@ trait BuildsModules
     }
 
     /**
+     * Return products module.
+     *
+     * @return Products
+     */
+    public function products()
+    {
+        return new Products($this);
+    }
+
+    /**
+     * Return product variants module.
+     *
+     * @param  Contracts\HasUri  $owner
+     * @return ProductVariants
+     */
+    public function productVariants(Contracts\HasUri $owner)
+    {
+        return new ProductVariants($this, $owner);
+    }
+
+    /**
      * Return redeem module.
      *
      * @param Contracts\HasUri $owner

--- a/src/Modules/ProductVariants.php
+++ b/src/Modules/ProductVariants.php
@@ -4,6 +4,7 @@ namespace Omneo\Modules;
 
 use Omneo\Client;
 use Omneo\Contracts;
+use Omneo\Constraint;
 use Omneo\ProductVariant;
 use Illuminate\Support\Collection;
 
@@ -32,16 +33,16 @@ class ProductVariants extends Module
     /**
      * Fetch listing of product variants.
      *
+     * @param Constraint|null $constraint
      * @return Collection|ProductVariant[]
      */
-    public function browse()
+    public function browse(Constraint $constraint = null)
     {
         return $this->buildCollection(
-            $this->client->get(sprintf(
-                '%s/%s',
-                $this->owner->uri(),
-                'variants'
-            )),
+            $this->client->get(
+                sprintf('%s/%s', $this->owner->uri(), 'variants'),
+                $this->applyConstraint($constraint)
+            ),
             ProductVariant::class
         );
     }

--- a/src/Modules/ProductVariants.php
+++ b/src/Modules/ProductVariants.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Omneo\Modules;
+
+use Omneo\Client;
+use Omneo\Contracts;
+use Omneo\ProductVariant;
+use Illuminate\Support\Collection;
+
+class ProductVariants extends Module
+{
+    /**
+     * Owner entity.
+     *
+     * @var Contracts\HasUri
+     */
+    protected $owner;
+
+    /**
+     * Product Variants constructor.
+     *
+     * @param  Client  $client
+     * @param  Contracts\HasUri  $owner
+     */
+    public function __construct(Client $client, Contracts\HasUri $owner = null)
+    {
+        parent::__construct($client);
+
+        $this->owner = $owner;
+    }
+
+    /**
+     * Fetch listing of product variants.
+     *
+     * @return Collection|ProductVariant[]
+     */
+    public function browse()
+    {
+        return $this->buildCollection(
+            $this->client->get(sprintf(
+                '%s/%s',
+                $this->owner->uri(),
+                'variants'
+            )),
+            ProductVariant::class
+        );
+    }
+
+    /**
+     * Fetch a single product variant.
+     *
+     * @param  int  $id
+     * @return ProductVariant
+     */
+    public function read(int $id)
+    {
+        return $this->buildEntity(
+            $this->client->get(sprintf(
+                '%s/%s/%s',
+                $this->owner->uri(),
+                'variants',
+                $id
+            )),
+            ProductVariant::class
+        );
+    }
+
+    /**
+     * Edit the given product variant.
+     *
+     * @param  ProductVariant  $productVariant
+     * @return ProductVariant
+     * @throws \DomainException
+     */
+    public function edit(ProductVariant $productVariant)
+    {
+        if (! $productVariant->id) {
+            throw new \DomainException('Product variant must contain an ID to edit');
+        }
+
+        return $this->buildEntity(
+            $this->client->put(sprintf(
+                '%s/%s/%s',
+                $this->owner->uri(),
+                'variants',
+                $productVariant->id
+            ), [
+                'json' => $productVariant->getDirtyAttributeValues()
+            ]),
+            ProductVariant::class
+        );
+    }
+
+    /**
+     * Add the given product variant.
+     *
+     * @param  ProductVariant  $productVariant
+     * @return ProductVariant
+     */
+    public function add(ProductVariant $productVariant)
+    {
+        return $this->buildEntity(
+            $this->client->post(sprintf(
+                '%s/%s',
+                $this->owner->uri(),
+                'variants'
+            ), [
+                'json' => $productVariant->toArray()
+            ]),
+            ProductVariant::class
+        );
+    }
+
+    /**
+     * Delete the given product variant.
+     *
+     * @param  ProductVariant  $productVariant
+     * @return void
+     */
+    public function delete(ProductVariant $productVariant)
+    {
+        if (! $productVariant->id) {
+            throw new \DomainException('Product variant must contain an ID to delete');
+        }
+
+        $this->client->delete(sprintf(
+            '%s/%s/%s',
+            $this->owner->uri(),
+            'variants',
+            $productVariant->id
+        ));
+    }
+}

--- a/src/Modules/Products.php
+++ b/src/Modules/Products.php
@@ -71,7 +71,7 @@ class Products extends Module
             $this->client->post('products', [
                 'json' => $product->toArray()
             ]),
-            Products::class
+            Product::class
         );
     }
 

--- a/src/Modules/Products.php
+++ b/src/Modules/Products.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Omneo\Modules;
+
+use Omneo\Product;
+use Omneo\Constraint;
+use Omneo\PaginatedCollection;
+
+class Products extends Module
+{
+    /**
+     * Fetch listing of products.
+     *
+     * @param  Constraint  $constraint
+     * @return PaginatedCollection|Product[]
+     */
+    public function browse(Constraint $constraint = null)
+    {
+        return $this->buildPaginatedCollection(
+            $this->client->get('products', $this->applyConstraint($constraint)),
+            Product::class,
+            [$this, __FUNCTION__],
+            $constraint
+        );
+    }
+
+    /**
+     * Fetch a single product.
+     *
+     * @param  string  $id
+     * @return Product
+     */
+    public function read(string $id)
+    {
+        return $this->buildEntity(
+            $this->client->get(sprintf('products/%s', $id)),
+            Product::class
+        );
+    }
+
+    /**
+     * Edit the given product.
+     *
+     * @param  Product  $product
+     * @return Product
+     * @throws \DomainException
+     */
+    public function edit(Product $product)
+    {
+        if (! $product->id) {
+            throw new \DomainException('Product must contain an ID to edit');
+        }
+
+        return $this->buildEntity(
+            $this->client->put(sprintf('products/%s', $product->id), [
+                'json' => $product->getDirtyAttributeValues()
+            ]),
+            Product::class
+        );
+    }
+
+    /**
+     * Create the given product.
+     *
+     * @param  Product  $product
+     * @return Product
+     */
+    public function add(Product $product)
+    {
+        return $this->buildEntity(
+            $this->client->post('products', [
+                'json' => $product->toArray()
+            ]),
+            Products::class
+        );
+    }
+
+    /**
+     * Delete the given product.
+     *
+     * @param  Product  $product
+     * @return void
+     */
+    public function delete(Product $product)
+    {
+        if (! $product->id) {
+            throw new \DomainException('Product must contain an ID to delete');
+        }
+
+        $this->client->delete(sprintf('products/%s', $product->id));
+    }
+}

--- a/src/Product.php
+++ b/src/Product.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Omneo;
+
+class Product extends Entity implements Contracts\HasUri
+{
+    /**
+     * Return URI for this entity.
+     *
+     * @return string
+     */
+    public function uri()
+    {
+        return sprintf('products/%s', $this->id);
+    }
+}

--- a/src/Product.php
+++ b/src/Product.php
@@ -2,6 +2,8 @@
 
 namespace Omneo;
 
+use Illuminate\Support\Collection;
+
 class Product extends Entity implements Contracts\HasUri
 {
     /**
@@ -12,5 +14,16 @@ class Product extends Entity implements Contracts\HasUri
     public function uri()
     {
         return sprintf('products/%s', $this->id);
+    }
+
+    /**
+     * Get the variants.
+     *
+     * @param array $variants
+     * @return Collection|ProductVariant[]
+     */
+    public function getVariantsAttribute(array $variants)
+    {
+        return collect($variants)->mapInto(ProductVariant::class);
     }
 }

--- a/src/ProductVariant.php
+++ b/src/ProductVariant.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Omneo;
+
+class ProductVariant extends Entity
+{
+    //
+}


### PR DESCRIPTION
This PR introduces a new `Products` and `ProductVariants` module into the SDK.

All of the BREAD methods are implemented for both the product and the product variant:

```
$product = $client->products()->read($id); // Get a product
$client->productVariants($product)->browse(); // Get all of the variants.
```